### PR TITLE
Add ironic node cleaning tunable

### DIFF
--- a/ansible/undercloud/templates/undercloud.10.conf.j2
+++ b/ansible/undercloud/templates/undercloud.10.conf.j2
@@ -173,7 +173,7 @@ inspection_iprange = 192.0.2.5,192.0.2.50
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
-#clean_nodes = false
+clean_nodes = {{ironic_node_cleaning}}
 
 
 [auth]

--- a/ansible/undercloud/templates/undercloud.11.conf.j2
+++ b/ansible/undercloud/templates/undercloud.11.conf.j2
@@ -178,7 +178,7 @@ inspection_iprange = 192.168.24.5,192.168.24.50
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
-#clean_nodes = false
+clean_nodes = {{ironic_node_cleaning}}
 
 # List of enabled bare metal drivers. (list value)
 #enabled_drivers = pxe_ipmitool,pxe_drac,pxe_ilo,pxe_ssh

--- a/ansible/undercloud/templates/undercloud.12.conf.j2
+++ b/ansible/undercloud/templates/undercloud.12.conf.j2
@@ -209,7 +209,7 @@ inspection_iprange = 192.168.24.5,192.168.24.50
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
-#clean_nodes = false
+clean_nodes = {{ironic_node_cleaning}}
 
 # List of enabled bare metal drivers. (list value)
 #enabled_drivers = pxe_ipmitool,pxe_drac,pxe_ilo

--- a/ansible/undercloud/vars/main.yml
+++ b/ansible/undercloud/vars/main.yml
@@ -55,3 +55,7 @@ dns_server: 8.8.8.8
 
 # instackenv:
 instackenv_json:
+
+
+# enables or disables ironic node cleaning for OSP>9
+ironic_node_cleaning: true


### PR DESCRIPTION
This adds a tunable for node cleaning to the undercloud.conf template
for osp versions > 9

Not tested ATM, would appreciate if someone gave this a run if they have an env to deploy anyways. I can't see any reason why this should break anything but I know better than to expect that means it works. 