### PR TITLE
Replace openstack baremetal bulk start command

### DIFF
--- a/ansible/undercloud/templates/introspect.sh.j2
+++ b/ansible/undercloud/templates/introspect.sh.j2
@@ -19,7 +19,8 @@ source /home/stack/stackrc
 ## * Introspect hardware attributes of nodes.
 ## ::
 
-openstack baremetal introspection bulk start
+openstack overcloud node introspect --all-manageable --provide
+
 
 {% endif %}
 


### PR DESCRIPTION
Replacing baremetal bulk start with overcloud node instrospect
--all-manageable --provide.