### PR TITLE
Fix clean-interfaces to be compatible with RHEL9

### DIFF
--- a/misc-tools/clean-interfaces.sh
+++ b/misc-tools/clean-interfaces.sh
@@ -30,18 +30,36 @@ if [ "$mode" == "--nuke" ]; then
   nuke=true
 fi
 
-filelist="$(grep IPADDR=172 /etc/sysconfig/network-scripts/* | awk -F: '{ print $1 }')"
+if [ $(rpm --eval "%{lua:print(rpm.vercmp($(rpm -qf /etc/redhat-release --queryformat '%{VERSION}\n'), '9.0'))}") -lt 0 ]; then
 
-if $disable ; then
-  for f in $filelist ; do
-    ifdown $(basename $f | awk -F- '{ print $2 }')
-    sed -i -e 's/ONBOOT=yes/ONBOOT=no/g' $f
-  done
-fi
+    filelist="$(grep IPADDR=172 /etc/sysconfig/network-scripts/* | awk -F: '{ print $1 }')"
 
-if $nuke ; then
-  for f in $filelist ; do
-    ifdown $(basename $f | awk -F- '{ print $2 }')
-    rm -f $f
-  done
+    if $disable ; then
+      for f in $filelist ; do
+        ifdown $(basename $f | awk -F- '{ print $2 }')
+        sed -i -e 's/ONBOOT=yes/ONBOOT=no/g' $f
+      done
+    fi
+
+    if $nuke ; then
+      for f in $filelist ; do
+        ifdown $(basename $f | awk -F- '{ print $2 }')
+        rm -f $f
+      done
+    fi
+
+else
+    alluuids=$(nmcli -g uuid c show)
+    uuidlist=$(for uuid in $alluuids ; do (nmcli c show $uuid | grep ipv4.address | awk '{ print $NF }') | grep -E -q ^172. && echo $uuid ; done)
+    for uuid in $uuidlist ; do
+        if $disable ; then
+            /usr/bin/nmcli connection down $uuid
+            /usr/bin/nmcli connection modify $uuid autoconnect false
+        fi
+
+        if $nuke ; then
+            /usr/bin/nmcli connection down $uuid
+            /usr/bin/nmcli connection delete $uuid
+        fi
+    done
 fi


### PR DESCRIPTION
This version is slightly different than the version you get via foreman templates, as we don't have knowledge of the various possible interface names in the templates for different models.

However, we can safely look for and nuke (or disable) interfaces with 172.x.x.x addresses

Reported by: https://issues.redhat.com/browse/SCALELAB-3321
Fixes: https://issues.redhat.com/browse/PERFINFRA-232